### PR TITLE
fix(dependencies): Import GetDashboardDataUseCase

### DIFF
--- a/src/config/dependencies.js
+++ b/src/config/dependencies.js
@@ -84,6 +84,9 @@ const InitializeDepositUseCase = require('../application/use-cases/wallet/initia
 const GetTransactionHistoryUseCase = require('../application/use-cases/wallet/get-transaction-history.usecase.js');
 const RequestWithdrawalUseCase = require('../application/use-cases/wallet/request-withdrawal.usecase.js');
 
+// Dashboard Use Cases
+const GetDashboardDataUseCase = require('../application/use-cases/dashboard/get-dashboard-data.usecase.js');
+
 
 // Infrastructure
 const LocalFileUploader = require('../infrastructure/file-upload/local.file-uploader.js');


### PR DESCRIPTION
This commit fixes a `ReferenceError: GetDashboardDataUseCase is not defined` that occurred during server startup. The use case was being instantiated in `src/config/dependencies.js` without being imported first.

This change adds the necessary import statement, resolving the startup error.